### PR TITLE
feat: add personal library for liked news

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+newsflow-main/node_modules

--- a/newsflow-main/src/App.tsx
+++ b/newsflow-main/src/App.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect } from 'react';
-import { Settings, RefreshCw, Newspaper, TrendingUp } from 'lucide-react';
+import { Settings, RefreshCw, Newspaper, TrendingUp, BookOpen } from 'lucide-react';
 import { SwipeableCard } from './components/SwipeableCard';
 import { SettingsModal } from './components/SettingsModal';
+import { LibraryModal } from './components/LibraryModal';
 import { usePreferences } from './hooks/usePreferences';
-import { mockNews, getPersonalizedNews, getRandomNews } from './data/mockNews';
+import { getPersonalizedNews, getRandomNews } from './data/mockNews';
 import { NewsArticle, SwipeAction } from './types';
 
 function App() {
@@ -12,8 +13,10 @@ function App() {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [seenArticleIds, setSeenArticleIds] = useState<string[]>([]);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const [isLibraryOpen, setIsLibraryOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [stats, setStats] = useState({ liked: 0, passed: 0 });
+  const [library, setLibrary] = useState<{ [category: string]: NewsArticle[] }>({});
 
   const loadNewArticles = () => {
     setIsLoading(true);
@@ -53,6 +56,14 @@ function App() {
 
   const handleSwipe = (swipeAction: SwipeAction) => {
     updatePreferences(swipeAction);
+
+    if (swipeAction.direction === 'right') {
+      const category = swipeAction.article.category || 'Other';
+      setLibrary(prev => ({
+        ...prev,
+        [category]: [...(prev[category] || []), swipeAction.article]
+      }));
+    }
     
     // Update stats
     setStats(prev => ({
@@ -91,6 +102,12 @@ function App() {
               </div>
             </div>
             <div className="flex items-center gap-3">
+              <button
+                onClick={() => setIsLibraryOpen(true)}
+                className="w-9 h-9 bg-gray-100 hover:bg-gray-200 rounded-full flex items-center justify-center transition-colors"
+              >
+                <BookOpen className="w-4 h-4 text-gray-600" />
+              </button>
               <button
                 onClick={() => setIsSettingsOpen(true)}
                 className="w-9 h-9 bg-gray-100 hover:bg-gray-200 rounded-full flex items-center justify-center transition-colors"
@@ -192,6 +209,11 @@ function App() {
         onClose={() => setIsSettingsOpen(false)}
         preferences={preferences}
         onUpdateRatio={setPersonalizedRatio}
+      />
+      <LibraryModal
+        isOpen={isLibraryOpen}
+        onClose={() => setIsLibraryOpen(false)}
+        library={library}
       />
     </div>
   );

--- a/newsflow-main/src/components/LibraryModal.tsx
+++ b/newsflow-main/src/components/LibraryModal.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { X } from 'lucide-react';
+import { NewsArticle } from '../types';
+
+interface LibraryModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  library: { [category: string]: NewsArticle[] };
+}
+
+export const LibraryModal: React.FC<LibraryModalProps> = ({ isOpen, onClose, library }) => {
+  if (!isOpen) return null;
+
+  const categories = Object.keys(library);
+
+  return (
+    <div className="fixed inset-0 bg-black/30 backdrop-blur-sm flex items-center justify-center z-40">
+      <div className="bg-white rounded-xl shadow-lg max-w-lg w-full max-h-[90vh] overflow-y-auto p-6">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-xl font-bold text-gray-900">Personal Library</h2>
+          <button
+            onClick={onClose}
+            className="p-2 rounded-full hover:bg-gray-100 transition-colors"
+          >
+            <X className="w-5 h-5 text-gray-600" />
+          </button>
+        </div>
+        {categories.length === 0 ? (
+          <p className="text-gray-500">No articles liked yet.</p>
+        ) : (
+          <div className="space-y-6">
+            {categories.map(category => (
+              <div key={category}>
+                <h3 className="text-lg font-semibold text-gray-800 mb-2">{category}</h3>
+                <div className="flex flex-wrap gap-2">
+                  {library[category].map(article => (
+                    <span
+                      key={article.id}
+                      className="px-3 py-1 bg-gray-100 rounded-full text-sm text-gray-700"
+                    >
+                      {article.title}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default LibraryModal;


### PR DESCRIPTION
## Summary
- add personal library modal to show liked articles grouped by category
- store liked articles by category when swiping right
- add library button in header for quick access

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689936377c888329aa4ed0423eacdcef